### PR TITLE
Parameter support #4

### DIFF
--- a/lib/citibike.js
+++ b/lib/citibike.js
@@ -11,6 +11,7 @@
  */
 var http = require('http')
   , utils = require('./utils')
+  , querystring = require('querystring');
 
 /**
  * Class for handling communications with Citibike's API.
@@ -65,6 +66,9 @@ Citibike.prototype.get = function( url, params, callback ) {
 
     if (url.charAt(0) == '/')
         url = this.options.restBase + url;
+
+    if (params !== null)
+        url = url + "?" + querystring.stringify(params);
 
     // Holds data from HTTP response body
     var body = []

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -162,4 +162,46 @@ describe('Citibike API - Stations', function () {
           done();
         });
     });
+
+    it('responds with json and only updated data', function (done) {
+      request
+        .get(citibike.defaults.stationsStreamURL)
+        .set('Accept', 'application/json')
+        .expect(200)
+        .end(function(err, res) {
+          should.not.exist(err);
+
+          // Headers
+          res.header['content-type'].should.eql('application/json; charset=utf8');
+
+          // Content
+          /* Expected Response:
+          {
+            ok: true,
+            meta: [ ],
+            results: [
+              {
+                id: 72,
+                status: "Active",
+                availableBikes: 8,
+                availableDocks: 26
+              }
+            ],
+            lastUpdate: 1367853737
+          } */
+
+          res.body.ok.should.eql(true);
+          res.body.results.should.not.be.empty;
+
+          var sampleResult = res.body.results[0];
+
+          sampleResult.id.should.be.a('number');
+          sampleResult.status.should.be.a('string');
+          sampleResult.availableBikes.should.be.a('number');
+          sampleResult.availableDocks.should.be.a('number');
+          should.not.exist(sampleResult.latitude);
+
+          done();
+        });
+    });
 });

--- a/test/citibike.test.js
+++ b/test/citibike.test.js
@@ -47,6 +47,16 @@ describe('Citibike.getStations()', function () {
         done();
       });
     });
+    it('should successfully complete request with params', function (done) {
+      citibike.getStations({updateOnly: "true"}, function(data) {
+        should.exist(data);
+        data.results.should.not.be.empty;
+        sampleResult = data.results[0];
+        should.exist(sampleResult.availableBikes);
+        should.not.exist(sampleResult.latitude);
+        done();
+      });
+    });
 });
 
 describe('Citibike.getBranches()', function () {


### PR DESCRIPTION
Added support for parameters because I really need the updateOnly version of stations. I don't know how to tell if it is actually a streaming API, but even without a read stream it will be helpful.

```
Citibike.getStations({updateOnly: "true"}, function(data) {
  console.log('data');
};
```

should return

```
{
  {
    'id': 1,
    'status': 'active',
    'availableBikes': 10,
    'availableDocks': 20
  },
  ...
}
```
